### PR TITLE
Add pause and exit controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # beer-game-reloaded
+
+Simple catch game demo. Use the mouse or arrow keys to move the player.
+
+## Controls
+
+- **Arrow keys / Mouse** - move player left and right.
+- **P** - pause/resume the game.
+- **Escape** - exit the game loop.
+- **H** - toggle the help overlay.

--- a/core/Game.js
+++ b/core/Game.js
@@ -5,6 +5,10 @@ export class Game {
         this.currentScene = initialScene;
         this.lastTimestamp = 0;
         this.input = null;
+        this.paused = false;
+        this.running = false;
+        this.frameId = null;
+        this.helpElement = null;
     }
 
     async start() {
@@ -19,11 +23,16 @@ export class Game {
             canvas.height = this.height;
         }
 
+        // Help overlay element
+        this.helpElement = document.getElementById('help-overlay');
+
         // Init scene
         await this.currentScene.init(this);
 
         // Start loop
-        requestAnimationFrame(this.gameLoop.bind(this));
+        this.running = true;
+        this.paused = false;
+        this.frameId = requestAnimationFrame(this.gameLoop.bind(this));
     }
 
     async changeScene(newScene) {
@@ -31,13 +40,44 @@ export class Game {
         await newScene.init(this);
     }
 
+    stop() {
+        this.running = false;
+        if (this.frameId) {
+            cancelAnimationFrame(this.frameId);
+            this.frameId = null;
+        }
+    }
+
     gameLoop(timestamp) {
+        if (!this.running) return;
+
         const dt = (timestamp - this.lastTimestamp) / 1000 || 0;
         this.lastTimestamp = timestamp;
 
-        this.currentScene.update(dt, this.input);
-        this.currentScene.render();
+        if (this.input.consumeKeyPress('p')) {
+            this.paused = !this.paused;
+        }
 
-        requestAnimationFrame(this.gameLoop.bind(this));
+        if (this.input.consumeKeyPress('Escape')) {
+            this.stop();
+            return;
+        }
+
+        if (this.input.consumeKeyPress('h')) {
+            this.toggleHelp();
+        }
+
+        if (!this.paused) {
+            this.currentScene.update(dt, this.input);
+            this.currentScene.render();
+        }
+
+        this.frameId = requestAnimationFrame(this.gameLoop.bind(this));
+    }
+
+    toggleHelp() {
+        if (!this.helpElement) return;
+        const showing = this.helpElement.style.display === 'block';
+        this.helpElement.style.display = showing ? 'none' : 'block';
     }
 }

--- a/core/InputManager.js
+++ b/core/InputManager.js
@@ -1,11 +1,23 @@
 export class InputManager {
     constructor() {
         this.keys = new Set();
-        window.addEventListener('keydown', e => this.keys.add(e.key));
+        this.justPressed = new Set();
+        window.addEventListener('keydown', e => {
+            this.keys.add(e.key);
+            this.justPressed.add(e.key);
+        });
         window.addEventListener('keyup', e => this.keys.delete(e.key));
     }
 
     isKeyPressed(key) {
         return this.keys.has(key);
+    }
+
+    consumeKeyPress(key) {
+        if (this.justPressed.has(key)) {
+            this.justPressed.delete(key);
+            return true;
+        }
+        return false;
     }
 }

--- a/index.html
+++ b/index.html
@@ -6,10 +6,42 @@
     <style>
         body { margin: 0; background: #222; }
         canvas { background: #222; display: block; margin: 0 auto; }
+        #help-overlay {
+            display: none;
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: rgba(0, 0, 0, 0.8);
+            color: #fff;
+            font-family: Arial, sans-serif;
+            padding: 20px;
+            box-sizing: border-box;
+        }
+        #help-overlay h1 {
+            text-align: center;
+            margin-top: 0;
+        }
+        #help-overlay ul {
+            list-style: none;
+            padding-left: 0;
+        }
     </style>
 </head>
 <body>
 <canvas id="game-canvas" width="800" height="600"></canvas>
+<div id="help-overlay">
+    <h1>Help</h1>
+    <p>Controls:</p>
+    <ul>
+        <li>Arrow keys / Mouse - move player</li>
+        <li>P - pause/resume the game</li>
+        <li>Escape - exit the game</li>
+        <li>H - toggle this help</li>
+    </ul>
+    <p>Press H to close</p>
+</div>
 <script type="module" src="./main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `consumeKeyPress` helper to manage single press events
- add pause/exit logic in `Game` loop
- document controls in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687e2e859df4832c914ee524b87dc3f0