### PR TITLE
Improve help overlay and input priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ Simple catch game demo. Use the mouse or arrow keys to move the player.
 - **Arrow keys / Mouse** - move player left and right.
 - **P** - pause/resume the game.
 - **Escape** - exit the game loop.
-- **H** - toggle the help overlay.
+- **H** - toggle the help overlay (pauses the game).

--- a/core/Game.js
+++ b/core/Game.js
@@ -9,6 +9,7 @@ export class Game {
         this.running = false;
         this.frameId = null;
         this.helpElement = null;
+        this.pausedBeforeHelp = false;
     }
 
     async start() {
@@ -78,6 +79,15 @@ export class Game {
     toggleHelp() {
         if (!this.helpElement) return;
         const showing = this.helpElement.style.display === 'block';
-        this.helpElement.style.display = showing ? 'none' : 'block';
+        if (showing) {
+            // Closing help overlay - restore previous pause state
+            this.helpElement.style.display = 'none';
+            this.paused = this.pausedBeforeHelp;
+        } else {
+            // Opening help overlay - remember pause state and pause game
+            this.pausedBeforeHelp = this.paused;
+            this.paused = true;
+            this.helpElement.style.display = 'block';
+        }
     }
 }

--- a/systems/InputSystem.js
+++ b/systems/InputSystem.js
@@ -14,15 +14,18 @@ export class InputSystem {
         if (!player) return;
 
         // Keyboard controls
-        if (input.isKeyPressed('ArrowLeft')) {
+        const left = input.isKeyPressed('ArrowLeft');
+        const right = input.isKeyPressed('ArrowRight');
+
+        if (left) {
             player.x -= player.speed * dt;
         }
-        if (input.isKeyPressed('ArrowRight')) {
+        if (right) {
             player.x += player.speed * dt;
         }
 
-        // Mouse controls
-        if (this.mouseX !== null) {
+        // Mouse controls (only when no arrow keys pressed)
+        if (!left && !right && this.mouseX !== null) {
             player.x = this.mouseX - player.width / 2;
         }
 


### PR DESCRIPTION
## Summary
- pause the game when the help overlay is shown and restore pause state when closed
- make keyboard arrows override mouse movement
- document that help pauses the game

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e34f8d71c832c8f34f4b9b7d85ce6