### PR TITLE
Enable asset replacement for player and items

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,9 @@ Simple catch game demo. Use the mouse or arrow keys to move the player.
 - **P** - pause/resume the game.
 - **Escape** - exit the game loop.
 - **H** - toggle the help overlay.
+
+## Replacing assets
+
+The graphics for the player box and falling items are loaded from
+`assets/player.svg` and `assets/item.svg`. Replace these files with your own
+images (PNG, SVG, etc.) to customise how the game looks.

--- a/assets/item.svg
+++ b/assets/item.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="30" height="30">
+  <rect width="30" height="30" fill="orange" />
+</svg>

--- a/assets/player.svg
+++ b/assets/player.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="30">
+  <rect width="100" height="30" fill="blue" />
+</svg>

--- a/entities/Item.js
+++ b/entities/Item.js
@@ -1,14 +1,15 @@
 let idCounter = 1;
 
 export class Item {
-    constructor(x, y, width, height, score) {
+    constructor(x, y, width, height, score, image = null) {
         this.id = idCounter++;
         this.x = x;
         this.y = y;
-        this.width = width;
-        this.height = height;
+        this.width = width || (image ? image.width : 0);
+        this.height = height || (image ? image.height : 0);
         this.speed = 200; // px/s
         this.score = score;
         this.type = 'item';
+        this.image = image;
     }
 }

--- a/entities/Item.js
+++ b/entities/Item.js
@@ -5,8 +5,8 @@ export class Item {
         this.id = idCounter++;
         this.x = x;
         this.y = y;
-        this.width = width || (image ? image.width : 0);
-        this.height = height || (image ? image.height : 0);
+        this.width = width !== null && width !== undefined ? width : (image ? image.width : 0);
+        this.height = height !== null && height !== undefined ? height : (image ? image.height : 0);
         this.speed = 200; // px/s
         this.score = score;
         this.type = 'item';

--- a/entities/Player.js
+++ b/entities/Player.js
@@ -1,10 +1,11 @@
 export class Player {
-    constructor(x, y, width, height) {
+    constructor(x, y, width, height, image = null) {
         this.x = x;
         this.y = y;
-        this.width = width;
-        this.height = height;
+        this.width = width || (image ? image.width : 0);
+        this.height = height || (image ? image.height : 0);
         this.speed = 400; // px/s
         this.type = 'player';
+        this.image = image;
     }
 }

--- a/entities/Player.js
+++ b/entities/Player.js
@@ -2,8 +2,8 @@ export class Player {
     constructor(x, y, width, height, image = null) {
         this.x = x;
         this.y = y;
-        this.width = width || (image ? image.width : 0);
-        this.height = height || (image ? image.height : 0);
+        this.width = width !== null && width !== undefined ? width : (image ? image.width : 0);
+        this.height = height !== null && height !== undefined ? height : (image ? image.height : 0);
         this.speed = 400; // px/s
         this.type = 'player';
         this.image = image;

--- a/scenes/GameScene.js
+++ b/scenes/GameScene.js
@@ -5,6 +5,15 @@ import { InputSystem } from '../systems/InputSystem.js';
 import { ItemSystem } from '../systems/ItemSystem.js';
 import { CollisionSystem } from '../systems/CollisionSystem.js';
 
+function loadImage(src) {
+    return new Promise((resolve, reject) => {
+        const img = new Image();
+        img.onload = () => resolve(img);
+        img.onerror = reject;
+        img.src = src;
+    });
+}
+
 export class GameScene extends Scene {
     async init(game) {
         super.init(game);
@@ -14,16 +23,23 @@ export class GameScene extends Scene {
         const canvas = document.getElementById('game-canvas');
         const ctx = canvas.getContext('2d');
 
+        // Load images
+        const playerImg = await loadImage('assets/player.svg');
+        const itemImg = await loadImage('assets/item.svg');
+
         // Create player
         const player = new Player(
-            canvas.width / 2 - 50, canvas.height - 50,
-            100, 30
+            canvas.width / 2 - playerImg.width / 2,
+            canvas.height - playerImg.height,
+            playerImg.width,
+            playerImg.height,
+            playerImg
         );
         this.addEntity(player);
 
         // Add systems
         this.addSystem(new InputSystem(canvas));
-        this.addSystem(new ItemSystem(canvas, this.scoreRef));
+        this.addSystem(new ItemSystem(canvas, this.scoreRef, itemImg));
         this.addSystem(new CollisionSystem(canvas, this.scoreRef));
         this.addSystem(new RenderSystem(ctx, this.scoreRef));
     }

--- a/scenes/GameScene.js
+++ b/scenes/GameScene.js
@@ -24,9 +24,29 @@ export class GameScene extends Scene {
         const ctx = canvas.getContext('2d');
 
         // Load images
-        const playerImg = await loadImage('assets/player.svg');
-        const itemImg = await loadImage('assets/item.svg');
-
+        let playerImg, itemImg;
+        try {
+            playerImg = await loadImage('assets/player.svg');
+        } catch (error) {
+            console.error('Failed to load player image:', error);
+            playerImg = document.createElement('canvas');
+            playerImg.width = 50; // Default width
+            playerImg.height = 50; // Default height
+            const ctx = playerImg.getContext('2d');
+            ctx.fillStyle = 'gray'; // Placeholder color
+            ctx.fillRect(0, 0, playerImg.width, playerImg.height);
+        }
+        try {
+            itemImg = await loadImage('assets/item.svg');
+        } catch (error) {
+            console.error('Failed to load item image:', error);
+            itemImg = document.createElement('canvas');
+            itemImg.width = 30; // Default width
+            itemImg.height = 30; // Default height
+            const ctx = itemImg.getContext('2d');
+            ctx.fillStyle = 'gray'; // Placeholder color
+            ctx.fillRect(0, 0, itemImg.width, itemImg.height);
+        }
         // Create player
         const player = new Player(
             canvas.width / 2 - playerImg.width / 2,

--- a/systems/ItemSystem.js
+++ b/systems/ItemSystem.js
@@ -1,11 +1,12 @@
 import { Item } from '../entities/Item.js';
 
 export class ItemSystem {
-    constructor(canvas, scoreRef) {
+    constructor(canvas, scoreRef, itemImage = null) {
         this.canvas = canvas;
         this.spawnInterval = 1.0; // seconds
         this.timer = 0;
         this.scoreRef = scoreRef;
+        this.itemImage = itemImage;
     }
 
     update(entities, dt) {
@@ -13,9 +14,11 @@ export class ItemSystem {
         this.timer += dt;
         if (this.timer >= this.spawnInterval) {
             this.timer = 0;
-            const x = Math.random() * (this.canvas.width - 30);
+            const imgW = this.itemImage ? this.itemImage.width : 30;
+            const x = Math.random() * (this.canvas.width - imgW);
             const score = 10;
-            entities.push(new Item(x, 0, 30, 30, score));
+            const imgH = this.itemImage ? this.itemImage.height : 30;
+            entities.push(new Item(x, 0, imgW, imgH, score, this.itemImage));
         }
 
         // Move items down

--- a/systems/RenderSystem.js
+++ b/systems/RenderSystem.js
@@ -10,15 +10,23 @@ export class RenderSystem {
 
         // Draw items
         entities.filter(e => e.type === 'item').forEach(item => {
-            ctx.fillStyle = 'orange';
-            ctx.fillRect(item.x, item.y, item.width, item.height);
+            if (item.image) {
+                ctx.drawImage(item.image, item.x, item.y, item.width, item.height);
+            } else {
+                ctx.fillStyle = 'orange';
+                ctx.fillRect(item.x, item.y, item.width, item.height);
+            }
         });
 
         // Draw player
         const player = entities.find(e => e.type === 'player');
         if (player) {
-            ctx.fillStyle = 'blue';
-            ctx.fillRect(player.x, player.y, player.width, player.height);
+            if (player.image) {
+                ctx.drawImage(player.image, player.x, player.y, player.width, player.height);
+            } else {
+                ctx.fillStyle = 'blue';
+                ctx.fillRect(player.x, player.y, player.width, player.height);
+            }
         }
 
         // Draw score (top right)


### PR DESCRIPTION
## Summary
- add basic SVG assets for the player and item
- allow `Player` and `Item` entities to store an image
- update ItemSystem and RenderSystem to use images if present
- load assets in GameScene and pass them into systems
- document how to replace assets

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_687e352f2ee4832c94933c7972597d48